### PR TITLE
Id shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # <!-- markdownlint-disable first-line-h1 no-inline-html -->
 ## 2.9.1 (January 9, 2024)
+
 CHORES:
 * Added shim helper functions that allows users to use vmware generated id or hostname as the id for a resource.  The reason for doing this is that whenever an esxi host is removed from vmware for whatever reason (maintenance, power outage etc.) and re-added, vmware generates a new host id for the same host which breaks any resource using that host id (which is most of them).  By using hostname as id, whenever the same host gets re-added back to vmware nothing breaks as the hostname will stay the same after being re-added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # <!-- markdownlint-disable first-line-h1 no-inline-html -->
+## 2.9.1 (January 9, 2024)
+CHORES:
+* Added shim helper functions that allows users to use vmware generated id or hostname as the id for a resource.  The reason for doing this is that whenever an esxi host is removed from vmware for whatever reason (maintenance, power outage etc.) and re-added, vmware generates a new host id for the same host which breaks any resource using that host id (which is most of them).  By using hostname as id, whenever the same host gets re-added back to vmware nothing breaks as the hostname will stay the same after being re-added
+
 ## 2.9.0 (December 5, 2023)
 
 FEATURES:

--- a/vsphere/internal/helper/hostsystem/host_system_helper.go
+++ b/vsphere/internal/helper/hostsystem/host_system_helper.go
@@ -124,8 +124,8 @@ func FromHostname(client *govmomi.Client, hostname string) (*object.HostSystem, 
 
 	if host != nil {
 		return host, nil
-
 	}
+
 	return nil, ErrHostnameNotFound
 }
 

--- a/vsphere/internal/helper/hostsystem/host_system_helper.go
+++ b/vsphere/internal/helper/hostsystem/host_system_helper.go
@@ -158,11 +158,11 @@ func FromHostnameOrID(client *govmomi.Client, d *schema.ResourceData) (*object.H
 	if d.Get("host_system_id") != nil && d.Get("host_system_id") != "" {
 		tfIDName = "host_system_id"
 		tfVal = d.Get(tfIDName).(string)
-		host, err = FromID(client, tfIDName)
+		host, err = FromID(client, tfVal)
 	} else if d.Get("hostname") != nil && d.Get("hostname") != "" {
 		tfIDName = "hostname"
 		tfVal = d.Get(tfIDName).(string)
-		host, err = FromHostname(client, tfIDName)
+		host, err = FromHostname(client, tfVal)
 	} else {
 		return nil, hostReturn{}, fmt.Errorf("no valid tf id attribute passed.  One of the following should be passed from resource: 'host_system_id', 'hostname'")
 	}

--- a/vsphere/internal/helper/hostsystem/host_system_helper.go
+++ b/vsphere/internal/helper/hostsystem/host_system_helper.go
@@ -5,17 +5,26 @@ package hostsystem
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/view"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
+)
+
+var (
+	ErrHostnameNotFound = errors.New("could not find host with given hostname")
 )
 
 // SystemOrDefault returns a HostSystem from a specific host name and
@@ -58,6 +67,74 @@ func FromID(client *govmomi.Client, id string) (*object.HostSystem, error) {
 	}
 	log.Printf("[DEBUG] Host system found: %s", hs.Reference().Value)
 	return hs.(*object.HostSystem), nil
+}
+
+// FromHostname locates a HostSystem by hostname
+// Will return error type "ErrHostnameNotFound" if no host is found
+func FromHostname(client *govmomi.Client, hostname string) (*object.HostSystem, error) {
+	log.Printf("[DEBUG] Locating host system with hostname %s", hostname)
+	finder := find.NewFinder(client.Client, false)
+
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+
+	dcs, err := finder.DatacenterList(ctx, "*")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, dc := range dcs {
+		viewMgr := view.NewManager(client.Client)
+		dcView, err := viewMgr.CreateContainerView(ctx, dc.Reference(), []string{"HostSystem"}, true)
+		if err != nil {
+			fmt.Printf("error trying to create container: %s", err)
+			os.Exit(1)
+		}
+
+		var hosts []mo.HostSystem
+		if err = dcView.RetrieveWithFilter(ctx, []string{"HostSystem"}, []string{"name"}, &hosts, property.Filter{}); err != nil {
+			fmt.Printf("error trying to retrieve hosts: %s", err)
+			os.Exit(1)
+		}
+
+		// Loop through hosts for given dc and determine if exists
+		// Throws error if can't find
+		for _, host := range hosts {
+			if host.Name == hostname {
+				f := find.NewFinder(client.Client, true)
+				ref, err := f.ObjectReference(ctx, host.Self)
+				if err != nil {
+					return nil, fmt.Errorf("error trying to retrieve host object reference: %s", err)
+				}
+
+				return ref.(*object.HostSystem), nil
+			}
+		}
+	}
+
+	return nil, ErrHostnameNotFound
+}
+
+// FromHostnameOrID locates HostSystem by either id or hostname depending on what's passed through ResourceData
+// Returns hostsystem along with identifier used to get hostsystem passed from ResourceData
+func FromHostnameOrID(client *govmomi.Client, d *schema.ResourceData) (*object.HostSystem, string, error) {
+	var hostID string
+	var host *object.HostSystem
+	var err error
+
+	if d.Get("host_system_id").(string) != "" {
+		hostID = d.Get("host_system_id").(string)
+		host, err = FromID(client, d.Get("host_system_id").(string))
+	} else {
+		hostID = d.Get("hostname").(string)
+		host, err = FromHostname(client, d.Get("hostname").(string))
+	}
+
+	if err != nil {
+		return nil, "", fmt.Errorf("error while trying to retrieve host '%s': %s", hostID, err)
+	}
+
+	return host, hostID, nil
 }
 
 // Properties is a convenience method that wraps fetching the HostSystem MO

--- a/vsphere/internal/helper/hostsystem/host_system_helper.go
+++ b/vsphere/internal/helper/hostsystem/host_system_helper.go
@@ -174,7 +174,7 @@ func FromHostnameOrID(client *govmomi.Client, d *schema.ResourceData) (*object.H
 	return host, hostReturn{IDName: tfIDName, Value: tfVal}, nil
 }
 
-// CheckIfHostname is a helper function that allows users to pass in an id and determine if that id exists
+// CheckIfHostnameOrID is a helper function that allows users to pass in an id and determine if that id exists
 // based on either the vmware generated host id or hostname
 //
 // The bool that is returned indicates whether the "tfID" parameter passed was found by hostname
@@ -182,26 +182,26 @@ func FromHostnameOrID(client *govmomi.Client, d *schema.ResourceData) (*object.H
 //
 // This is a "shim" function that is mainly used in import functions of any resource that relies on an esxi host id
 // or hostname as an attribute
-func CheckIfHostname(client *govmomi.Client, tfID string) (*object.HostSystem, bool, error) {
+func CheckIfHostnameOrID(client *govmomi.Client, tfID string) (*object.HostSystem, hostReturn, error) {
 	host, err := FromID(client, tfID)
 	if err != nil {
 		if !viapi.IsManagedObjectNotFoundError(err) {
-			return nil, false, err
+			return nil, hostReturn{}, err
 		}
 
 		host, err = FromHostname(client, tfID)
 		if err != nil {
 			if !errors.Is(err, ErrHostnameNotFound) {
-				return nil, false, err
+				return nil, hostReturn{}, err
 			}
 
-			return nil, false, fmt.Errorf("could not find host based off of id or hostname")
+			return nil, hostReturn{}, fmt.Errorf("could not find host based off of id or hostname")
 		}
 
-		return host, true, nil
+		return host, hostReturn{IDName: "hostname", Value: host.Name()}, nil
 	}
 
-	return host, false, nil
+	return host, hostReturn{IDName: "host_system_id", Value: host.Reference().Value}, nil
 }
 
 // Properties is a convenience method that wraps fetching the HostSystem MO

--- a/vsphere/internal/helper/hostsystem/host_system_helper.go
+++ b/vsphere/internal/helper/hostsystem/host_system_helper.go
@@ -141,14 +141,12 @@ func FromHostname(client *govmomi.Client, hostname string) (*object.HostSystem, 
 // FromHostnameOrID locates HostSystem by either id or hostname depending on what's passed through ResourceData
 // Returns hostsystem along with identifier used to get hostsystem passed from ResourceData
 //
-// This is a "shim" function to allow backwards compatibility for resources currently using the generated vmware id
-// as value for any resource that requires an esxi id as attribute or to use the new way of using a hostname as the id
-// for any resource that requires an esxi id
+// This is a "shim" function thats allows users to use vmware generated id or hostname as the id for a resource
 //
 // The reason for doing this is that whenever an esxi host is removed from vmware for whatever reason (maintenance, power outage etc.)
 // and re-added, vmware generates a new id for the same host which breaks any resource using that id (which is most of them)
 //
-// This function, along with updating the attribute api of any resources using esxi host id, allows users to continue using vmware
+// This function, along with updating the attribute api of any resources using esxi host id, will allow users to continue using vmware
 // generated id without breaking but also allows users to use hostname as the id which generally doesn't change and/or is unique
 func FromHostnameOrID(client *govmomi.Client, d *schema.ResourceData) (*object.HostSystem, hostReturn, error) {
 	var tfIDName, tfVal string

--- a/vsphere/internal/helper/hostsystem/host_system_helper.go
+++ b/vsphere/internal/helper/hostsystem/host_system_helper.go
@@ -23,6 +23,15 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+// hostReturn is a config struct that allows us to return both the esxi host id key name
+// along with its value
+//
+// This is mainly used for the "FromHostnameOrID" shim function
+type hostReturn struct {
+	IDName string
+	Value  string
+}
+
 var (
 	ErrHostnameNotFound = errors.New("could not find host with given hostname")
 )
@@ -131,24 +140,68 @@ func FromHostname(client *govmomi.Client, hostname string) (*object.HostSystem, 
 
 // FromHostnameOrID locates HostSystem by either id or hostname depending on what's passed through ResourceData
 // Returns hostsystem along with identifier used to get hostsystem passed from ResourceData
-func FromHostnameOrID(client *govmomi.Client, d *schema.ResourceData) (*object.HostSystem, string, error) {
-	var hostID string
+//
+// This is a "shim" function to allow backwards compatibility for resources currently using the generated vmware id
+// as value for any resource that requires an esxi id as attribute or to use the new way of using a hostname as the id
+// for any resource that requires an esxi id
+//
+// The reason for doing this is that whenever an esxi host is removed from vmware for whatever reason (maintenance, power outage etc.)
+// and re-added, vmware generates a new id for the same host which breaks any resource using that id (which is most of them)
+//
+// This function, along with updating the attribute api of any resources using esxi host id, allows users to continue using vmware
+// generated id without breaking but also allows users to use hostname as the id which generally doesn't change and/or is unique
+func FromHostnameOrID(client *govmomi.Client, d *schema.ResourceData) (*object.HostSystem, hostReturn, error) {
+	var tfIDName, tfVal string
 	var host *object.HostSystem
 	var err error
 
-	if d.Get("host_system_id").(string) != "" {
-		hostID = d.Get("host_system_id").(string)
-		host, err = FromID(client, d.Get("host_system_id").(string))
+	if d.Get("host_system_id") != nil && d.Get("host_system_id") != "" {
+		tfIDName = "host_system_id"
+		tfVal = d.Get(tfIDName).(string)
+		host, err = FromID(client, tfIDName)
+	} else if d.Get("hostname") != nil && d.Get("hostname") != "" {
+		tfIDName = "hostname"
+		tfVal = d.Get(tfIDName).(string)
+		host, err = FromHostname(client, tfIDName)
 	} else {
-		hostID = d.Get("hostname").(string)
-		host, err = FromHostname(client, d.Get("hostname").(string))
+		return nil, hostReturn{}, fmt.Errorf("no valid tf id attribute passed.  One of the following should be passed from resource: 'host_system_id', 'hostname'")
 	}
 
 	if err != nil {
-		return nil, "", fmt.Errorf("error while trying to retrieve host '%s': %s", hostID, err)
+		return nil, hostReturn{}, fmt.Errorf("error while trying to retrieve host '%s': %s", tfVal, err)
 	}
 
-	return host, hostID, nil
+	return host, hostReturn{IDName: tfIDName, Value: tfVal}, nil
+}
+
+// CheckIfHostname is a helper function that allows users to pass in an id and determine if that id exists
+// based on either the vmware generated host id or hostname
+//
+// The bool that is returned indicates whether the "tfID" parameter passed was found by hostname
+// If "tfID" was found by hostname, will return true
+//
+// This is a "shim" function that is mainly used in import functions of any resource that relies on an esxi host id
+// or hostname as an attribute
+func CheckIfHostname(client *govmomi.Client, tfID string) (*object.HostSystem, bool, error) {
+	host, err := FromID(client, tfID)
+	if err != nil {
+		if !viapi.IsManagedObjectNotFoundError(err) {
+			return nil, false, err
+		}
+
+		host, err = FromHostname(client, tfID)
+		if err != nil {
+			if !errors.Is(err, ErrHostnameNotFound) {
+				return nil, false, err
+			}
+
+			return nil, false, fmt.Errorf("could not find host based off of id or hostname")
+		}
+
+		return host, true, nil
+	}
+
+	return host, false, nil
 }
 
 // Properties is a convenience method that wraps fetching the HostSystem MO

--- a/vsphere/internal/helper/hostsystem/host_system_helper.go
+++ b/vsphere/internal/helper/hostsystem/host_system_helper.go
@@ -124,8 +124,8 @@ func FromHostname(client *govmomi.Client, hostname string) (*object.HostSystem, 
 
 	if host != nil {
 		return host, nil
-	}
 
+	}
 	return nil, ErrHostnameNotFound
 }
 


### PR DESCRIPTION
- Added shim helper functions that allows users to use vmware generated id or hostname as the id for a resource